### PR TITLE
add support for OpenVPN "export" API calls

### DIFF
--- a/opnsense_cli/api/base.py
+++ b/opnsense_cli/api/base.py
@@ -26,9 +26,9 @@ class ApiBase():
         self._command = value
 
     def _api_call(api_function):
-        def api_response(self, *args):
+        def api_response(self, *args, json=None):
             api_function(self)
             return self._api_client.execute(
-                *args, module=self.module, controller=self.controller, method=self.method, command=self.command)
+                *args, module=self.module, controller=self.controller, method=self.method, command=self.command, json=json)
 
         return api_response

--- a/opnsense_cli/api/openvpn.py
+++ b/opnsense_cli/api/openvpn.py
@@ -1,0 +1,39 @@
+from opnsense_cli.api.base import ApiBase
+
+
+class Openvpn(ApiBase):
+    MODULE = "openvpn"
+    CONTROLLER = "export"
+    """
+    OPENVPN EXPORT
+    """
+
+    @ApiBase._api_call
+    def accounts(self, *args, **kwargs):
+        self.method = "get"
+        self.command = "accounts"
+
+    @ApiBase._api_call
+    def download(self, *args, json=None, **kwargs):
+        self.method = "post"
+        self.command = "download"
+
+    @ApiBase._api_call
+    def providers(self, *args, **kwargs):
+        self.method = "get"
+        self.command = "providers"
+
+    @ApiBase._api_call
+    def storePresets(self, *args, **kwargs):
+        self.method = "post"
+        self.command = "storePresets"
+
+    @ApiBase._api_call
+    def templates(self, *args, **kwargs):
+        self.method = "get"
+        self.command = "templates"
+
+    @ApiBase._api_call
+    def validatePresets(self, *args, **kwargs):
+        self.method = "post"
+        self.command = "validatePresets"

--- a/opnsense_cli/cli.py
+++ b/opnsense_cli/cli.py
@@ -7,6 +7,7 @@ from opnsense_cli import __cli_name__
 from opnsense_cli.api.client import ApiClient
 from opnsense_cli.command.version import version
 from opnsense_cli.command.plugin import plugin
+from opnsense_cli.command.openvpn import openvpn
 
 CFG_DIR = f"~/.{__cli_name__}"
 DEFAULT_CFG = f"{CFG_DIR}/conf.yaml"
@@ -145,6 +146,7 @@ def cli(ctx, **kwargs):
 # register commands
 cli.add_command(version)
 cli.add_command(plugin)
+cli.add_command(openvpn)
 
 if __name__ == "__main__":
     cli()

--- a/opnsense_cli/command/openvpn.py
+++ b/opnsense_cli/command/openvpn.py
@@ -1,0 +1,196 @@
+import click
+
+from opnsense_cli.command.output import CliOutput
+from opnsense_cli.api.client import ApiClient
+from opnsense_cli.api.openvpn import Openvpn
+
+pass_api_client = click.make_pass_decorator(ApiClient)
+pass_openvpn_svc = click.make_pass_decorator(Openvpn)
+
+@click.group()
+@pass_api_client
+@click.pass_context
+def openvpn(ctx, api_client: ApiClient, **kwargs):
+    """
+    Manage OpenVPN
+    """
+    ctx.obj = Openvpn(api_client)
+
+@openvpn.command()
+@click.argument('vpnid')
+@click.option(
+    '--output', '-o',
+    help=' Output format.',
+    default="table",
+    type=click.Choice(['table', 'json']),
+    show_default=True,
+)
+@click.option(
+    '--cols', '-c',
+    help='Which columns should be printed?',
+    default="<ID>,description,users",
+    show_default=True,
+)
+@pass_openvpn_svc
+def accounts(openvpn_svc: Openvpn, **kwargs):
+    """
+    Show all accounts for a OpenVPN server.
+
+    VPNID is the ID of the OpenVPN server (use "providers" to get a list).
+    """
+    result = openvpn_svc.accounts(kwargs['vpnid'])
+
+    CliOutput(result, kwargs['output'], kwargs['cols'].split(",")).echo()
+
+
+@openvpn.command()
+@click.argument('vpnid')
+@click.argument('certref')
+@click.option(
+    '--auth_nocache',
+    default="0",
+    type=int,
+    show_default=True,
+)
+@click.option(
+    '--cryptoapi',
+    default="0",
+    type=int,
+    show_default=True,
+)
+@click.option(
+    '--hostname',
+    type=str,
+    required=False,
+)
+@click.option(
+    '--local_port',
+    default="1194",
+    type=int,
+    show_default=True,
+)
+@click.option(
+    '--p12_password',
+    type=str,
+    required=False,
+)
+@click.option(
+    '--p12_password_confirm',
+    type=str,
+    required=False,
+)
+@click.option(
+    '--plain_config',
+    type=str,
+    required=False,
+)
+@click.option(
+    '--random_local_port',
+    default="1",
+    type=int,
+    required=False,
+    show_default=True,
+)
+@click.option(
+    '--servers',
+    type=int,
+    required=False,
+    show_default=True,
+)
+@click.option(
+    '--template',
+    default="PlainOpenVPN",
+    type=str,
+    show_default=True,
+)
+@click.option(
+    '--validate_server_cn',
+    default="1",
+    type=int,
+    show_default=True,
+)
+
+@click.option(
+    '--output', '-o',
+    help=' Output format.',
+    default="table",
+    type=click.Choice(['table', 'json']),
+    show_default=True,
+)
+@click.option(
+    '--cols', '-c',
+    help='Which columns should be printed?',
+    # NOTE: "content" is base64 encoded, otherwise the binary content
+    # would scramble the console. (Whether or not binary content is actually
+    # returned by the API depends on the value of --template.)
+    default="filename,content",
+    show_default=True,
+)
+@pass_openvpn_svc
+def download(openvpn_svc: Openvpn, **kwargs):
+    """
+    Download client config for chosen OpenVPN server and account.
+
+    VPNID is the ID of the OpenVPN server (use "providers" to get a list).
+    CERTREF is the ID of the OpenVPN account (use "accounts" to get a list).
+    """
+    json = {
+        'openvpn_export': {
+        }
+    }
+    options = ['auth_nocache', 'cryptoapi', 'hostname', 'local_port', 'p12_password', 'p12_password_confirm', 'plain_config', 'random_local_port', 'servers', 'template', 'validate_server_cn']
+    for option in options:
+      if kwargs[option] != None: json['openvpn_export'][option] = kwargs[option]
+
+    result = openvpn_svc.download(kwargs['vpnid'],kwargs['certref'],json=json)
+
+    CliOutput(result, kwargs['output'], kwargs['cols'].split(",")).echo()
+
+
+@openvpn.command()
+@click.option(
+    '--output', '-o',
+    help=' Output format.',
+    default="table",
+    type=click.Choice(['table', 'json']),
+    show_default=True,
+)
+@click.option(
+    '--cols', '-c',
+    help='Which columns should be printed?',
+    default="<ID>,name,mode,vpnid,hostname,template,local_port",
+    show_default=True,
+)
+@pass_openvpn_svc
+def providers(openvpn_svc: Openvpn, **kwargs):
+    """
+    Show all available OpenVPN servers.
+    """
+    result = openvpn_svc.providers()
+
+    CliOutput(result, kwargs['output'], kwargs['cols'].split(",")).echo()
+
+
+@openvpn.command()
+@click.option(
+    '--output', '-o',
+    help=' Output format.',
+    default="table",
+    type=click.Choice(['table', 'json']),
+    show_default=True,
+)
+@click.option(
+    '--cols', '-c',
+    help='Which columns should be printed?',
+    default="<ID>,name,supportedOptions",
+    show_default=True,
+)
+@pass_openvpn_svc
+def templates(openvpn_svc: Openvpn, **kwargs):
+    """
+    Show all available export templates.
+    """
+    result = openvpn_svc.templates()
+
+    CliOutput(result, kwargs['output'], kwargs['cols'].split(",")).echo()
+

--- a/opnsense_cli/tests/command/tests/test_openvpn.py
+++ b/opnsense_cli/tests/command/tests/test_openvpn.py
@@ -1,0 +1,129 @@
+import unittest
+from unittest.mock import patch
+from click.testing import CliRunner
+from opnsense_cli.api.client import ApiClient
+from opnsense_cli.command.openvpn import openvpn
+
+
+class TestOpenvpnCommands(unittest.TestCase):
+    def setUp(self):
+        self._api_data_fixtures_providers = {
+            "2": {
+                "name": "OpenVPN Server UDP:1194",
+                "mode": "server_tls",
+                "vpnid": "2",
+                "hostname": "vpn.example.com",
+                "template": "PlainOpenVPN",
+                "local_port": "1194",
+                "random_local_port": "1",
+                "validate_server_cn": "1",
+                "cryptoapi": "",
+                "auth_nocache": "",
+                "plain_config": ""
+            },
+        }
+        self._api_data_fixtures_templates = {
+            "ArchiveOpenVPN": {
+                "name": "Archive",
+                "supportedOptions": ["plain_config", "p12_password", "random_local_port", "auth_nocache", "cryptoapi"]
+            },
+            "PlainOpenVPN": {
+                "name": "File Only",
+                "supportedOptions": ["plain_config", "random_local_port", "auth_nocache", "cryptoapi"]
+            },
+            "TheGreenBow": {
+                "name": "TheGreenBow",
+                "supportedOptions": []
+            },
+            "ViscosityVisz": {
+                "name": "Viscosity (visz)",
+                "supportedOptions": ["plain_config", "p12_password", "random_local_port", "auth_nocache", "cryptoapi"]
+            },
+        }
+        self._api_data_fixtures_accounts = {
+            "57194c007be18": {
+                "description": "vpnuser1", "users": []
+            },
+            "57194c17cab84": {
+                "description": "vpnuser2", "users": []
+            },
+        }
+        self._api_data_fixtures_download = {
+            "result": "ok",
+            "changed": "false",
+            "filename": "OpenVPN_Server_vpnuser1.ovpn",
+            "filetype": "text/plain",
+            "content": "T3BlblZQTiBjZXJ0aWZpY2F0ZQo="
+        }
+        self._api_client_args_fixtures = [
+            'api_key',
+            'api_secret',
+            'https://127.0.0.1/api',
+            True,
+            '~/.opn-cli/ca.pem',
+            60
+        ]
+
+    @patch('opnsense_cli.command.openvpn.ApiClient.execute')
+    def test_providers(self, api_response_mock):
+        api_response_mock.return_value = self._api_data_fixtures_providers
+        client_args = self._api_client_args_fixtures
+        client = ApiClient(*client_args)
+
+        runner = CliRunner()
+        result = runner.invoke(openvpn, ['providers'], obj=client)
+
+        self.assertIn(
+            "2 OpenVPN Server UDP:1194 server_tls 2 vpn.example.com PlainOpenVPN 1194\n",
+            result.output
+        )
+        self.assertEqual(0, result.exit_code)
+
+    @patch('opnsense_cli.command.openvpn.ApiClient.execute')
+    def test_templates(self, api_response_mock):
+        api_response_mock.return_value = self._api_data_fixtures_templates
+        client_args = self._api_client_args_fixtures
+        client = ApiClient(*client_args)
+
+        runner = CliRunner()
+        result = runner.invoke(openvpn, ['templates'], obj=client)
+
+        self.assertIn(
+            "ArchiveOpenVPN Archive ['plain_config', 'p12_password', 'random_local_port', 'auth_nocache', 'cryptoapi']\n" +
+            "PlainOpenVPN File Only ['plain_config', 'random_local_port', 'auth_nocache', 'cryptoapi']\n"
+            "TheGreenBow TheGreenBow []\n"
+            "ViscosityVisz Viscosity (visz) ['plain_config', 'p12_password', 'random_local_port', 'auth_nocache', 'cryptoapi']\n",
+            result.output
+        )
+        self.assertEqual(0, result.exit_code)
+
+    @patch('opnsense_cli.command.openvpn.ApiClient.execute')
+    def test_accounts(self, api_response_mock):
+        api_response_mock.return_value = self._api_data_fixtures_accounts
+        client_args = self._api_client_args_fixtures
+        client = ApiClient(*client_args)
+
+        runner = CliRunner()
+        result = runner.invoke(openvpn, ['accounts', '2'], obj=client)
+
+        self.assertIn(
+            "57194c007be18 vpnuser1 []\n" +
+            "57194c17cab84 vpnuser2 []\n",
+            result.output
+        )
+        self.assertEqual(0, result.exit_code)
+
+    @patch('opnsense_cli.command.openvpn.ApiClient.execute')
+    def test_download(self, api_response_mock):
+        api_response_mock.return_value = self._api_data_fixtures_download
+        client_args = self._api_client_args_fixtures
+        client = ApiClient(*client_args)
+
+        runner = CliRunner()
+        result = runner.invoke(openvpn, ['download', '2', '57194c007be18'], obj=client)
+
+        self.assertIn(
+            "OpenVPN_Server_vpnuser1.ovpn T3BlblZQTiBjZXJ0aWZpY2F0ZQo=\n",
+            result.output
+        )
+        self.assertEqual(0, result.exit_code)


### PR DESCRIPTION
This implements all API calls that are currently available for OpenVPN:
https://docs.opnsense.org/development/api/core/openvpn.html

@andeman If possible, please create a new release (0.4?) after merging this. Thanks!

```
$ opn-cli openvpn                        
Usage: opn-cli openvpn [OPTIONS] COMMAND [ARGS]...

  Manage OpenVPN

Options:
  -h, --help  Show this message and exit.

Commands:
  accounts   Show all accounts for a OpenVPN server.
  download   Download client config for chosen OpenVPN server and account.
  providers  Show all available OpenVPN servers.
  templates  Show all available export templates.
```