### PR TITLE
ensure that JSON output is valid JSON

### DIFF
--- a/opnsense_cli/command/format.py
+++ b/opnsense_cli/command/format.py
@@ -1,4 +1,5 @@
 import click
+import json
 from abc import ABC, abstractmethod
 
 
@@ -22,7 +23,7 @@ class JsonFormat(BaseFormat):
     """
 
     def echo(self):
-        click.echo(self._data)
+        click.echo(json.dumps(self._data))
 
 
 class TableFormat(BaseFormat):

--- a/opnsense_cli/tests/command/tests/test_format.py
+++ b/opnsense_cli/tests/command/tests/test_format.py
@@ -42,11 +42,11 @@ class TestFormatter(unittest.TestCase):
         result = capturedOutput.getvalue()
 
         self.assertIn(
-            '[{\'name\': \'os-acme-client\', \'version\': \'2.4\', ' +
-            '\'comment\': "Let\'s Encrypt client", \'flatsize\': \'575KiB\', \'locked\': \'N/A\', ' +
-            '\'license\': \'BSD2CLAUSE\', \'repository\': \'OPNsense\', \'origin\': \'opnsense/os-acme-client\', ' +
-            '\'provided\': \'1\', \'installed\': \'0\', \'path\': \'OPNsense/opnsense/os-acme-client\', ' +
-            '\'configured\': \'0\'}]\n',
+            '[{"name": "os-acme-client", "version": "2.4", ' +
+            '"comment": "Let\'s Encrypt client", "flatsize": "575KiB", "locked": "N/A", ' +
+            '"license": "BSD2CLAUSE", "repository": "OPNsense", "origin": "opnsense/os-acme-client", ' +
+            '"provided": "1", "installed": "0", "path": "OPNsense/opnsense/os-acme-client", ' +
+            '"configured": "0"}]\n',
             result
         )
 


### PR DESCRIPTION
I've just noticed that using `--output json` generates invalid JSON:

```
# Python complains
json.decoder.JSONDecodeError: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)

# a random json linter complains too
Invalid string, it appears you used single quotes instead of double quotes
```