### PR TITLE
fix uppercase endpoint_params

### DIFF
--- a/opnsense_cli/api/client.py
+++ b/opnsense_cli/api/client.py
@@ -31,11 +31,11 @@ class ApiClient(object):
             raise APIException(response=response.status_code, resp_body=response.text, url=response.url)
 
     def _get_endpoint_url(self, *args, **kwargs):
-        endpoint = f"{kwargs['module']}/{kwargs['controller']}/{kwargs['command']}"
+        endpoint = f"{kwargs['module']}/{kwargs['controller']}/{kwargs['command']}".lower()
         endpoint_params = '/'.join(args)
         if endpoint_params:
-            return f"{endpoint}/{endpoint_params}".lower()
-        return endpoint.lower()
+            return f"{endpoint}/{endpoint_params}"
+        return endpoint
 
     def _get(self, endpoint):
         req_url = '{}/{}'.format(self._base_url, endpoint)


### PR DESCRIPTION
If Alias name is uppercase, method getAliasUUID isn't working.

Example with Alias GLOBAL_BL_API 

the endpoint_params in lowercase : 
KO - firewall/alias/getaliasuuid/global_bl_api 
`opn-cli firewall alias show GLOBAL_BL_API    
`
```
+------+------+------+-------+----------+-------------+------------+---------+---------+
| uuid | name | type | proto | counters | description | updatefreq | content | enabled |
+------+------+------+-------+----------+-------------+------------+---------+---------+
+------+------+------+-------+----------+-------------+------------+---------+---------+
```


the same with the real Alias name : 
OK - firewall/alias/getaliasuuid/GLOBAL_BL_API
`opn-cli firewall alias show GLOBAL_BL_API    
`
`+--------------------------------------+---------------+------+-------+----------+------------------------+------------+-------------------------------------------------------------------+---------+
|                 uuid                 |      name     | type | proto | counters |      description       | updatefreq |                              content                              | enabled |
+--------------------------------------+---------------+------+-------+----------+------------------------+------------+-------------------------------------------------------------------+---------+
| a6987428-1142-493d-9b15-80detgrt0f8433 | GLOBAL_BL_API | host |       |          | Blacklist |            | BL_1,BL_2 |    1    |
+--------------------------------------+---------------+------+-------+----------+------------------------+------------+-------------------------------------------------------------------+---------+`
