### PR TITLE
add missing dependency: dataclasses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         'jsonpath-ng',
         'beautifulsoup4',
         'lxml',
+        'dataclasses',
         'Jinja2'
     ],
     entry_points='''


### PR DESCRIPTION
When running the most recent version of opn-cli, the following error message is shown:

```
$ opn-cli openvpn download 1 1234567890 --hostname vpn.example.com --output json 
Traceback (most recent call last):
  File "/usr/local/bin/opn-cli", line 7, in <module>
    from opnsense_cli.cli import cli
  File "/usr/local/lib/python3.6/site-packages/opnsense_cli/cli.py", line 8, in <module>
    from opnsense_cli.commands.new.api import api as new_api
  File "/usr/local/lib/python3.6/site-packages/opnsense_cli/commands/new/api.py", line 4, in <module>
    from opnsense_cli.facades.code_generator.api import ApiCodeGenerator
  File "/usr/local/lib/python3.6/site-packages/opnsense_cli/facades/code_generator/api.py", line 2, in <module>
    from opnsense_cli.facades.template_engines.base import TemplateEngine
  File "/usr/local/lib/python3.6/site-packages/opnsense_cli/facades/template_engines/base.py", line 2, in <module>
    from dataclasses import dataclass
ModuleNotFoundError: No module named 'dataclasses'
```

It looks like opn-cli recently introduced a new dependency, that is not specified in the Python package list. After manually installing the `dataclasses` PIP the error was gone.

(FWIW, I'm preparing another PR, so maybe wait until my 2nd PR before issueing a new release.)