### PR TITLE
add api-backup plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,14 +1027,14 @@ Download a backup of the OPNsense system configuration to the current directory:
 
 ```
 $ opn-cli apibackup backup download
-sucessfully saved to: ./config.xml
+successfully saved to: ./config.xml
 ```
 
 Or specify a path and filename:
 
 ```
 $ opn-cli apibackup backup download -p /tmp/config_backup.xml
-sucessfully saved to: /tmp/config_backup.xml
+successfully saved to: /tmp/config_backup.xml
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ opn-cli - the OPNsense CLI written in python.
       - [host alias overrides](#host-alias-overrides)
       - [domain overrides](#domain-overrides)
       - [Examples](#examples)
+    + [Apibackup](#apibackup)
+      - [Examples](#examples)
   * [Development](#development)
     + [Setup development environment](#setup-development-environment)
     + [Testing](#testing)
@@ -1011,6 +1013,29 @@ opn-cli unbound alias create --host 'mailin|example.com|MX|10|mail.example.com|'
 opn-cli unbound domain create --domain rockin.com --server 192.168.56.3
 
 ```  
+
+### Apibackup
+This feature needs the opnsense plugin os-api-backup.
+
+```
+$ opn-cli plugin install os-api-backup
+```
+
+#### Examples
+
+Download a backup of the OPNsense system configuration to the current directory:
+
+```
+$ opn-cli apibackup backup download
+sucessfully saved to: ./config.xml
+```
+
+Or specify a path and filename:
+
+```
+$ opn-cli apibackup backup download -p /tmp/config_backup.xml
+sucessfully saved to: /tmp/config_backup.xml
+```
 
 ## Development
 

--- a/opnsense_cli/api/plugin/apibackup.py
+++ b/opnsense_cli/api/plugin/apibackup.py
@@ -1,0 +1,14 @@
+from opnsense_cli.api.base import ApiBase
+
+
+class Backup(ApiBase):
+    MODULE = "backup"
+    CONTROLLER = "backup"
+    """
+    api-backup BackupController
+    """
+
+    @ApiBase._api_call
+    def download(self, *args):
+        self.method = "get"
+        self.command = "download"

--- a/opnsense_cli/commands/plugin/apibackup/__init__.py
+++ b/opnsense_cli/commands/plugin/apibackup/__init__.py
@@ -1,0 +1,8 @@
+import click
+
+
+@click.group()
+def apibackup(**kwargs):
+    """
+    Manage api-backup operations
+    """

--- a/opnsense_cli/commands/plugin/apibackup/backup.py
+++ b/opnsense_cli/commands/plugin/apibackup/backup.py
@@ -1,0 +1,57 @@
+import click
+from opnsense_cli.formatters.cli_output import CliOutputFormatter
+from opnsense_cli.callbacks.click import \
+    formatter_from_formatter_name, expand_path, available_formats
+from opnsense_cli.commands.plugin.apibackup import apibackup
+from opnsense_cli.api.client import ApiClient
+from opnsense_cli.api.plugin.apibackup import Backup
+from opnsense_cli.facades.commands.plugin.apibackup.backup import ApibackupBackupFacade
+
+pass_api_client = click.make_pass_decorator(ApiClient)
+pass_apibackup_backup_svc = click.make_pass_decorator(ApibackupBackupFacade)
+
+
+@apibackup.group()
+@pass_api_client
+@click.pass_context
+def backup(ctx, api_client: ApiClient, **kwargs):
+    """
+    Manage api-backup
+    """
+    backup_api = Backup(api_client)
+    ctx.obj = ApibackupBackupFacade(backup_api)
+
+
+@backup.command()
+@click.option(
+    '-p', '--path',
+    help='The target path.',
+    type=click.Path(dir_okay=False),
+    default='./config.xml',
+    is_eager=True,
+    show_default=True,
+    callback=expand_path,
+    show_envvar=True,
+    required=True,
+)
+@click.option(
+    '--output', '-o',
+    help='Specifies the Output format.',
+    default="plain",
+    type=click.Choice(available_formats()),
+    callback=formatter_from_formatter_name,
+    show_default=True,
+)
+@click.option(
+    '--cols', '-c',
+    help='Which columns should be printed? Pass empty string (-c '') to show all columns',
+    default="status",
+    show_default=True,
+)
+@pass_apibackup_backup_svc
+def download(apibackup_backup_svc: ApibackupBackupFacade, **kwargs):
+    """
+    Download config.xml from OPNsense.
+    """
+    result = apibackup_backup_svc.download_backup(kwargs['path'])
+    CliOutputFormatter(result, kwargs['output'], kwargs['cols'].split(",")).echo()

--- a/opnsense_cli/facades/commands/plugin/apibackup/backup.py
+++ b/opnsense_cli/facades/commands/plugin/apibackup/backup.py
@@ -10,5 +10,5 @@ class ApibackupBackupFacade(ApibackupFacade):
         config = self._backup_api.download('json')
         self._write_base64_string_to_zipfile(path, config['content'])
         return {
-            "status": f"sucessfully saved to: {path}"
+            "status": f"successfully saved to: {path}"
         }

--- a/opnsense_cli/facades/commands/plugin/apibackup/backup.py
+++ b/opnsense_cli/facades/commands/plugin/apibackup/backup.py
@@ -1,0 +1,14 @@
+from opnsense_cli.api.plugin.apibackup import Backup
+from opnsense_cli.facades.commands.plugin.apibackup.base import ApibackupFacade
+
+
+class ApibackupBackupFacade(ApibackupFacade):
+    def __init__(self, backup_api: Backup):
+        self._backup_api = backup_api
+
+    def download_backup(self, path):
+        config = self._backup_api.download('json')
+        self._write_base64_string_to_zipfile(path, config['content'])
+        return {
+            "status": f"sucessfully saved to: {path}"
+        }

--- a/opnsense_cli/facades/commands/plugin/apibackup/base.py
+++ b/opnsense_cli/facades/commands/plugin/apibackup/base.py
@@ -1,0 +1,6 @@
+from opnsense_cli.facades.commands.base import CommandFacade
+
+
+class ApibackupFacade(CommandFacade):
+    def __init__(self):
+        super().__init__()

--- a/opnsense_cli/facades/commands/plugin/haproxy/config.py
+++ b/opnsense_cli/facades/commands/plugin/haproxy/config.py
@@ -27,5 +27,5 @@ class HaproxyConfigFacade(HaproxyFacade):
         config = self._export_api.download('all')
         self._write_base64_string_to_zipfile(path, config['content'])
         return {
-            "status": f"sucessfully saved zip to: {path}"
+            "status": f"successfully saved zip to: {path}"
         }

--- a/opnsense_cli/tests/commands/plugin/test_apibackup.py
+++ b/opnsense_cli/tests/commands/plugin/test_apibackup.py
@@ -1,0 +1,11 @@
+import unittest
+from click.testing import CliRunner
+from opnsense_cli.commands.plugin.apibackup import apibackup
+
+
+class TestApibackupCommands(unittest.TestCase):
+    def test_firewall(self):
+        runner = CliRunner()
+        result = runner.invoke(apibackup)
+
+        self.assertEqual(0, result.exit_code)

--- a/opnsense_cli/tests/commands/plugin/test_haproxy_config.py
+++ b/opnsense_cli/tests/commands/plugin/test_haproxy_config.py
@@ -169,7 +169,7 @@ class TestHaproxyConfigCommands(CommandTestCase):
         )
 
         self.assertIn(
-            "sucessfully saved zip to: ./haproxy_config_export.zip\n",
+            "successfully saved zip to: ./haproxy_config_export.zip\n",
             result.output
         )
         self.assertTrue(os.path.exists("./haproxy_config_export.zip"))


### PR DESCRIPTION
This PR adds support for the os-backup-api plugin.

Now it's easy to download a backup of the OPNsense system configuration to the current directory:

```
$ opn-cli apibackup backup download                              
successfully saved to: ./config.xml
```

Or specify an alternative path and filename:

```
$ opn-cli apibackup backup download -p /tmp/config_backup.xml
successfully saved to: /tmp/config_backup.xml
```

Note: This requires the upcoming release of os-backup-api 1.1, which will likely be released in OPNsense 23.1.2 soon.